### PR TITLE
feat: CI/ Github action to npm publish package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: Publish package to npm
+# When anyone pushes to npm branch in this repo, the package will be published to npm. This action requires
+# access to NPM_TOKEN secret. Contact core.ai admins to get access to core.ais org tokens.
+# To publish to your own npm account, follow this https://docs.npmjs.com/creating-and-viewing-access-tokens
+
+on:
+  push:
+    branches: [ npm ]
+
+jobs:
+  build-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          npm install
+          npm run build
+          npm publish
+      - env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # template-nodejs
 A template project for nodejs. Has integrated linting, testing,
-coverage, reporting, Github actions and other goodies.
+coverage, reporting, GitGub actions for publishing to npm repository and other goodies.
 
 Easily use this template to quick start a production ready nodejs project template.
 
@@ -108,6 +108,23 @@ Sample coverage report:
 Unit and integration test coverage settings can be updated by configs `.nycrc.unit.json` and `.nycrc.integration.json`.
 
 See https://github.com/istanbuljs/nyc for config options.
+
+# Publishing packages to NPM
+To publish a package to npm, push contents to `npm` branch in 
+this repository. 
+
+## Publishing `@aicore/package*`
+If you are looking to publish to package owned by core.ai, you will need access to the GitHub Organization secret `NPM_TOKEN`.
+
+For repos managed by [aicore](https://github.com/aicore) org in GitHub, Please contact your Admin to get access to core.ai's NPM tokens.
+
+
+## Publishing to your own npm account
+Alternatively, if you want to publish the package to your own npm account, please follow these docs:
+1. Create an automation access token by following this [link](https://docs.npmjs.com/creating-and-viewing-access-tokens).
+2. Add NPM_TOKEN to your repository secret by following this [link](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow)
+
+To edit the publishing workflow, please see file: `.github/workflows/npm-publish.yml`
 
 # Code Guardian
 Several automated workflows that check code integrity are integrated into this template.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "template-nodejs",
+  "name": "@aicore/template-nodejs",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "template-nodejs",
+      "name": "@aicore/template-nodejs",
       "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,18 @@
 {
-  "name": "template-nodejs",
+  "name": "@aicore/template-nodejs",
   "version": "1.0.0",
   "description": "Template for nodejs with unit gulp build, test, coverage, code guardian, github and Other defaults",
   "main": "index.js",
   "type": "module",
+  "keywords": [
+    "template",
+    "nodejs",
+    "unit",
+    "testing",
+    "mocha",
+    "chai",
+    "coverage"
+  ],
   "scripts": {
     "eslint": "npm run lint",
     "eslint:fix": "npm run lint:fix",
@@ -37,5 +46,7 @@
     "eslint": "8.6.0",
     "husky": "7.0.4",
     "mocha": "9.1.3"
+  },
+  "dependencies": {
   }
 }


### PR DESCRIPTION
* Push to `npm` branch in a repo to will automatically publish to npm provided the repo has access to NPM_TOKEN org secret of core.ai
* Updated docs in readme for `npm publish`

