### PR TITLE
Parameterize CLA check URLs

### DIFF
--- a/.github/workflows/python/verify_cla_signature_pr.py
+++ b/.github/workflows/python/verify_cla_signature_pr.py
@@ -78,7 +78,7 @@ def task_failed(comment):
 
 
 def extract_personal_contributer_details():
-    personal_cla_link = 'https://raw.githubusercontent.com/aicore/contributor-license-agreement/main/personal_contributor_licence_agreement.md'
+    personal_cla_link = sys.argv[1]
     f = requests.get(personal_cla_link)
     personal_cla_contents = f.text
 
@@ -90,7 +90,7 @@ def extract_personal_contributer_details():
 
 
 def extract_employer_contributer_details():
-    employer_cla_link = 'https://raw.githubusercontent.com/aicore/contributor-license-agreement/main/employer_contributor_license_agreement.md'
+    employer_cla_link = sys.argv[2]
     f = requests.get(employer_cla_link)
     employer_cla_contents = f.text
 

--- a/.github/workflows/verify_cla_signature_pr.yml
+++ b/.github/workflows/verify_cla_signature_pr.yml
@@ -49,12 +49,15 @@ jobs:
       - name: Review pull request
         run: |
           which git
-          if ! python ./.github/workflows/python/verify_cla_signature_pr.py; then
+          if ! python ./.github/workflows/python/verify_cla_signature_pr.py $PERSONAL_CLA_LINK $EMPLOYER_CLA_LINK; then
               echo "Pull request details could not be extracted"
               exit 1
           else
               echo "all good"
           fi
+        env:
+          EMPLOYER_CLA_LINK: https://raw.githubusercontent.com/aicore/contributor-license-agreement/main/employer_contributor_license_agreement.md
+          PERSONAL_CLA_LINK: https://raw.githubusercontent.com/aicore/contributor-license-agreement/main/personal_contributor_licence_agreement.md
       
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Solve issue https://github.com/aicore/template-nodejs/issues/48#issue-1194168604.
The hardcoded URLs to obtain personal/employer CLA file are now parameterized as a github environment variables.